### PR TITLE
Fix Cloud repo path in integration workflow

### DIFF
--- a/.github/workflows/integrations-updater.yml
+++ b/.github/workflows/integrations-updater.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Pubish to Meshery docs
         working-directory: ./meshery/mesheryctl
         run: |
-          ./mesheryctl registry publish remote-provider ${{ secrets.INTEGRATION_SPREADSHEET_CRED }} 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw ../meshmodels/models ../ui/public/img/meshmodels
+          ./mesheryctl registry publish remote-provider ${{ secrets.INTEGRATION_SPREADSHEET_CRED }} 1DZHnzxYWOlJ69Oguz4LkRVTFM79kC2tuvdwizOJmeMw ../meshery-cloud/meshmodels/models ../meshery-cloud/ui/public/img/meshmodels
       - name: Commit changes to Layer5.io repo
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

In last PR I made mistake in passing path for cloud, this PR fixes the issue


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
